### PR TITLE
Switch to CommonJS export in types

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,3 @@
 import toc from "@jsdevtools/rehype-toc";
 export * from "@jsdevtools/rehype-toc";
-export default toc;
+export = toc;


### PR DESCRIPTION
Thanks for `@jsdevtools/rehype-toc`!

To avoid having to access `.default` in `moduleResolution: 'Node16'` or newer:

[TypeScript Playground](https://www.typescriptlang.org/play/?target=99&moduleResolution=99&module=100#code/JYWwDg9gTgLgBFApgCwJ5kQFQgYwLIQAmArgDaJwBmUEIcA5AAIBWAzoYgG4wQSmsB6JGgwBaHjnoBuAFAycEAHat4IImUQBRAB4YcMRIQBccABQA6SwEMoAc1Ymri1AG0AugEo4AXgB8cJ1QfBBR0LFwCEnJZOVi4+SUVODUoxABBfWIrUhMAbzgOSisyGBMLazsHAOd3Lz9qoIBfYOEw7Hx1aLkFZXhC4tIYDJgsnLNLcxt7RxrPH39AltCMdsiNc36SmKA)

```ts
import rehypeTocModule from '@jsdevtools/rehype-toc';

const moduleExpected: (...args: any[]) => any = rehypeTocModule; // 💥

const moduleActual: { default: (...args: any[]) => any } = rehypeTocModule;

const defaultActual: (...args: any[]) => any = rehypeTocModule.default;
```

Error message:

```
'moduleExpected' is declared but its value is never read.(6133)
Type 'typeof import("file:///node_modules/@jsdevtools/rehype-toc/lib/index")' is not assignable to type '(...args: any[]) => any'.
  Type 'typeof import("file:///node_modules/@jsdevtools/rehype-toc/lib/index")' provides no match for the signature '(...args: any[]): any'.(2322)
```

Interestingly I don't see a problem on [Are the types wrong?](https://arethetypeswrong.github.io/?p=%40jsdevtools%2Frehype-toc%403.0.2):

![Screenshot 2024-07-29 at 19 11 08](https://github.com/user-attachments/assets/dc7547e0-866b-4fef-a6fb-2143044a73ce)


cc @andrewbranch